### PR TITLE
feat(gc): implement payment modification API (Refund)

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -21,7 +21,7 @@
         "dotenv": "16.4.5",
         "fastify": "5.0.0",
         "fastify-plugin": "5.0.1",
-        "qs": "^6.13.0"
+        "qs": "6.13.0"
       },
       "devDependencies": {
         "@jest/globals": "29.7.0",
@@ -35,7 +35,7 @@
         "eslint-plugin-prettier": "5.2.1",
         "eslint-plugin-unused-imports": "4.1.4",
         "jest": "29.7.0",
-        "msw": "^2.4.11",
+        "msw": "2.4.11",
         "node-fetch": "3.3.2",
         "nodemon": "3.1.7",
         "prettier": "3.3.3",

--- a/processor/package.json
+++ b/processor/package.json
@@ -31,7 +31,7 @@
     "dotenv": "16.4.5",
     "fastify": "5.0.0",
     "fastify-plugin": "5.0.1",
-    "qs": "^6.13.0"
+    "qs": "6.13.0"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/processor/src/clients/redemptions.ts
+++ b/processor/src/clients/redemptions.ts
@@ -1,0 +1,32 @@
+import * as T from './types/redemptions';
+
+import { encode, isObject, isString } from './helpers';
+
+import type { RequestController } from './voucherify-request-controller';
+
+export class Redemptions {
+  constructor(private client: RequestController) {}
+
+  public rollback(redemptionId: string, params?: T.RedemptionsRollbackParams) {
+    let queryParams: T.RedemptionsRollbackQueryParams = {};
+    let payload: T.RedemptionsRollbackPayload = {};
+
+    if (isString(params)) {
+      queryParams.reason = params;
+    } else if (isObject(params)) {
+      const { reason, tracking_id: trackingId, customer } = params;
+
+      queryParams = {
+        reason: reason ? reason : undefined,
+        tracking_id: trackingId ? trackingId : undefined,
+      };
+      payload = { customer };
+    }
+
+    return this.client.post<T.RedemptionsRollbackResponse>(
+      `/redemptions/${encode(redemptionId)}/rollback`,
+      payload,
+      queryParams,
+    );
+  }
+}

--- a/processor/src/clients/types/redemptions.ts
+++ b/processor/src/clients/types/redemptions.ts
@@ -1,0 +1,35 @@
+import { SimpleCustomer } from './customers';
+import { VouchersResponse } from './vouchers';
+
+export interface RedemptionsRollbackParams {
+  reason?: string;
+  tracking_id?: string;
+  customer?: SimpleCustomer & { description?: string };
+}
+
+export interface RedemptionsRollbackQueryParams {
+  reason?: string;
+  tracking_id?: string;
+}
+
+export interface RedemptionsRollbackPayload {
+  customer?: SimpleCustomer & { description?: string };
+}
+
+export interface RedemptionsRollbackResponse {
+  id: string;
+  object: 'redemption_rollback';
+  date?: string;
+  customer_id?: string;
+  tracking_id?: string;
+  redemption?: string;
+  amount?: number;
+  reason?: string;
+  result: 'SUCCESS' | 'FAILURE';
+  voucher?: VouchersResponse;
+  customer?: SimpleCustomer;
+  reward?: {
+    assignment_id: string;
+    object: 'reward';
+  };
+}

--- a/processor/src/clients/voucherify.ts
+++ b/processor/src/clients/voucherify.ts
@@ -2,6 +2,7 @@ import { RequestController } from './voucherify-request-controller';
 import { Vouchers } from './vouchers';
 import { Validations } from './validations';
 import { assert, isString, isObject } from './helpers';
+import { Redemptions } from './redemptions';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJSON = require('../../package.json');
@@ -113,9 +114,11 @@ export function Voucherify(options: VoucherifyOptions) {
 
   const vouchers = new Vouchers(client);
   const validations = new Validations(client);
+  const redemptions = new Redemptions(client);
 
   return {
     vouchers,
     validations,
+    redemptions,
   };
 }

--- a/processor/src/errors/voucherify-api.error.ts
+++ b/processor/src/errors/voucherify-api.error.ts
@@ -4,7 +4,7 @@ export type VoucherifyApiErrorData = {
   code: number;
   key: string;
   message: string;
-  details?: string; // TODO: to be thrown as part of private message, and can be logged also
+  details?: string;
 };
 
 export class VoucherifyApiError extends Errorx {

--- a/processor/src/services/converters/refund-payment.converter.ts
+++ b/processor/src/services/converters/refund-payment.converter.ts
@@ -1,8 +1,0 @@
-import { RefundPaymentRequest } from '../types/operation.type';
-
-export class RefundPaymentConverter {
-  public convertRequest(opts: RefundPaymentRequest): void {
-    console.log(opts);
-    return;
-  }
-}

--- a/processor/src/services/voucherify-giftcard.service.ts
+++ b/processor/src/services/voucherify-giftcard.service.ts
@@ -22,6 +22,7 @@ import { VoucherifyApiError, VoucherifyCustomError } from '../errors/voucherify-
 import { log } from '../libs/logger';
 import { BalanceConverter } from './converters/balance-converter';
 import { getCartIdFromContext } from '../libs/fastify/context/context';
+import { PaymentModificationStatus } from '../dtos/operations/payment-intents.dto';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJSON = require('../../package.json');
@@ -194,11 +195,16 @@ export class VoucherifyGiftCardService extends AbstractGiftCardService {
    * @returns Promise with mocking data containing operation status and PSP reference
    */
   async refundPayment(request: RefundPaymentRequest): Promise<PaymentProviderModificationResponse> {
-    throw new ErrorGeneral('operation not supported', {
-      fields: {
-        pspReference: request.payment.interfaceId,
-      },
-      privateMessage: "connector doesn't support refund operation yet",
+    const ctPayment = await this.ctPaymentService.getPayment({
+      id: request.payment.id,
     });
+    const redemptionId = ctPayment.interfaceId;
+    const rollbackResult = await VoucherifyAPI().redemptions.rollback(redemptionId as string);
+
+    return {
+      outcome:
+        rollbackResult.result === 'SUCCESS' ? PaymentModificationStatus.APPROVED : PaymentModificationStatus.REJECTED,
+      pspReference: rollbackResult.id,
+    };
   }
 }

--- a/processor/test/client/redemptions.spec.ts
+++ b/processor/test/client/redemptions.spec.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, afterEach, afterAll, beforeEach, jest, beforeAll } from '@jest/globals';
+import { voucherifyClient as client } from './client';
+import { setupServer } from 'msw/node';
+import { mockRequest } from '../mocks/utils';
+import { rollbackVouchersRedemptionOk } from '../mocks/voucherify';
+import { randomUUID } from 'crypto';
+
+describe('Redemptions API', () => {
+  const mockServer = setupServer();
+
+  beforeAll(() => {
+    mockServer.listen({
+      onUnhandledRequest: 'bypass',
+    });
+  });
+
+  beforeEach(() => {
+    jest.setTimeout(10000);
+    resetTestLibs();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  describe('rollback voucher redemption', () => {
+    test('should return required properties', async () => {
+      const redemptionId = randomUUID();
+      mockServer.use(
+        mockRequest(
+          'https://api.voucherify.io',
+          `/v1/redemptions/${redemptionId}/rollback`,
+          200,
+          rollbackVouchersRedemptionOk,
+        ),
+      );
+
+      const response = await client.redemptions.rollback(redemptionId);
+      expect(response.result).toBe('SUCCESS');
+      expect(response.id).toBeDefined();
+      expect(response.object).toBe('redemption_rollback');
+    });
+
+    test('should return required properties-with reason', async () => {
+      const redemptionId = randomUUID();
+      const reason = {
+        reason: 'Malfunctioned goods',
+      };
+      mockServer.use(
+        mockRequest(
+          'https://api.voucherify.io',
+          `/v1/redemptions/${redemptionId}/rollback`,
+          200,
+          rollbackVouchersRedemptionOk,
+        ),
+      );
+
+      const response = await client.redemptions.rollback(redemptionId, reason);
+      expect(response.result).toBe('SUCCESS');
+      expect(response.id).toBeDefined();
+      expect(response.object).toBe('redemption_rollback');
+    });
+  });
+});
+
+const resetTestLibs = () => {
+  jest.resetAllMocks();
+};

--- a/processor/test/mocks/coco.ts
+++ b/processor/test/mocks/coco.ts
@@ -1,4 +1,4 @@
-import { Cart } from '@commercetools/connect-payments-sdk';
+import { Cart, Payment } from '@commercetools/connect-payments-sdk';
 import { randomUUID } from 'crypto';
 
 export const getCartOK = () => {
@@ -49,4 +49,46 @@ export const getCartOK = () => {
     lastModifiedAt: '2024-01-01T00:00:00Z',
   };
   return mockGetCartResult;
+};
+
+export const getPaymentResultOk: Payment = {
+  id: '123456',
+  version: 1,
+  amountPlanned: {
+    type: 'centPrecision',
+    currencyCode: 'GBP',
+    centAmount: 120000,
+    fractionDigits: 2,
+  },
+  interfaceId: 'REDEMPTION_ID',
+  paymentMethodInfo: {
+    method: 'Debit Card',
+    name: { 'en-US': 'Debit Card', 'en-GB': 'Debit Card' },
+  },
+  paymentStatus: { interfaceText: 'Paid' },
+  transactions: [],
+  interfaceInteractions: [],
+  createdAt: '2024-02-13T00:00:00.000Z',
+  lastModifiedAt: '2024-02-13T00:00:00.000Z',
+};
+
+export const updatePaymentResultOk: Payment = {
+  id: '123456',
+  version: 1,
+  amountPlanned: {
+    type: 'centPrecision',
+    currencyCode: 'GBP',
+    centAmount: 120000,
+    fractionDigits: 2,
+  },
+  interfaceId: 'REDEMPTION_ID',
+  paymentMethodInfo: {
+    method: 'Debit Card',
+    name: { 'en-US': 'Debit Card', 'en-GB': 'Debit Card' },
+  },
+  paymentStatus: { interfaceText: 'Paid' },
+  transactions: [],
+  interfaceInteractions: [],
+  createdAt: '2024-02-13T00:00:00.000Z',
+  lastModifiedAt: '2024-02-13T00:00:00.000Z',
 };

--- a/processor/test/mocks/utils.ts
+++ b/processor/test/mocks/utils.ts
@@ -2,7 +2,14 @@
 import { http, HttpHandler, HttpResponse } from 'msw';
 
 export const mockRequest = (basePath: string, uri: string, respCode: number, data?: any): HttpHandler => {
-  return http.all(`${basePath}${uri}`, () => {
+  return http.all(`${basePath}${uri}`, ({ request }) => {
+    const url = new URL(request.url);
+    const reason = url.searchParams.get('reason');
+
+    if (reason) {
+      return HttpResponse.json(data);
+    }
+
     if (respCode === 401) {
       const errorData = {
         error: 'invalid_client',

--- a/processor/test/mocks/voucherify.ts
+++ b/processor/test/mocks/voucherify.ts
@@ -198,3 +198,29 @@ export const validateVouchersNotOk = {
   ],
   tracking_id: 'track_9B0kB92+bJa8a+PegaWREw==',
 };
+
+export const rollbackVouchersRedemptionOk = {
+  id: 'rr_0f90151bf1d0c97d06',
+  object: 'redemption_rollback',
+  date: '2024-10-23T12:40:47.875Z',
+  customer_id: null,
+  tracking_id: null,
+  metadata: null,
+  amount: -5000,
+  redemption: 'r_0f900b4b48c0fa9567',
+  reason: 'Product malfunction',
+  result: 'SUCCESS',
+  status: 'SUCCEEDED',
+  order: {},
+  channel: {
+    channel_id: 'b964e8d1-9087-4d91-ad24-44b6ca0f7884',
+    channel_type: 'API',
+  },
+  customer: null,
+  related_object_type: 'voucher',
+  related_object_id: 'v_a9xQHRQxEauu2yu56VxxXwnEFwnBg05f',
+  voucher: {},
+  gift: {
+    amount: -5000,
+  },
+};


### PR DESCRIPTION
Linked Ticket: https://commercetools.atlassian.net/browse/SCC-2623

Implements the payment modification endpoints and necessary tests.
For voucherify, support is only extended to refunds, cancel and capture aren't supported.

#### To test this endpoint:
1. Follow setup guide in Readme
2. You need a coco oauth token with the following permissions (`manage_project`, `manage_checkout_payment_intents`).
3. Get voucherify application ID and secret key from voucherify's dashboard
4. Create a campaign and with it a voucher, the voucher code you would need to make the call.
5. Redeem voucher through the endpoint being worked on here https://commercetools.atlassian.net/browse/SCC-2618

##### Example Request:
```curl
curl --location --globoff 'http://0.0.0.0:8080/operations/payment-intents/{{payment-id}}' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer {{ctp_access_token}}' \
--data '{
    "actions": [
        {
            "action": "refundPayment",
            "amount": {
                "centAmount": 11637,
                "currencyCode": "EUR"
            }
        }
    ]
}'
```

##### Example Response:
```json
{
    "outcome": "approved"
}
```