### PR TITLE
fix(giftcard): bind this to class methods

### DIFF
--- a/enabler/src/components/form.ts
+++ b/enabler/src/components/form.ts
@@ -31,6 +31,8 @@ export class FormComponent extends DefaultComponent {
   constructor(opts: { giftcardOptions: GiftCardOptions; baseOptions: BaseOptions }) {
     super(opts);
     this.i18n = new I18n(translations);
+    this.balance = this.balance.bind(this);
+    this.submit = this.submit.bind(this);
   }
 
   async balance(): Promise<BalanceType> {
@@ -50,7 +52,7 @@ export class FormComponent extends DefaultComponent {
       const jsonResponse = await response.json();
       if (!jsonResponse?.status?.state) {
         this.baseOptions.onError(jsonResponse);
-        return
+        return;
       }
 
       return jsonResponse;
@@ -60,16 +62,6 @@ export class FormComponent extends DefaultComponent {
   }
 
   async submit(params: { amount?: Amount }): Promise<void> {
-    if (this.giftcardOptions?.onGiftCardSubmit) {
-      this.giftcardOptions
-        .onGiftCardSubmit()
-        .then() // Not sure at this time what we do with the response here
-        .catch((err) => {
-          this.baseOptions.onError(err);
-          throw err;
-        });
-    }
-
     try {
       const giftCardCode = getInput(fieldIds.code).value.replace(/\s/g, '');
       const requestBody = {
@@ -123,14 +115,14 @@ export class FormComponent extends DefaultComponent {
   private _getField() {
     return `
       <div class="${inputFieldStyles.wrapper}">
-        <form class="${inputFieldStyles.paymentForm}">
+        <div class="${inputFieldStyles.paymentForm}">
           <div class="${inputFieldStyles.inputContainer}">
             <label class="${inputFieldStyles.inputLabel}" for="giftcard-code">
               ${this.i18n.translate('giftCardPlaceholder', this.baseOptions.locale)} <span aria-hidden="true"> *</span>
             </label>
             <input class="${inputFieldStyles.inputField}" type="text" id="giftcard-code" name="giftCardCode" value="">
           </div>
-        </form>
+        </div>
       </div>
     `;
   }

--- a/enabler/src/components/utils.ts
+++ b/enabler/src/components/utils.ts
@@ -10,18 +10,8 @@ export const fieldIds = {
 const handleChangeEvent = (field: string, onValueChange?: (hasValue: boolean) => Promise<void>) => {
   const input = getInput(field);
   if (input) {
-    let hasValue = false;
-
     input.addEventListener('input', () => {
-      if (!hasValue && input.value !== '') {
-        hasValue = true;
-
-        onValueChange?.(hasValue);
-      } else if (hasValue && input.value === '') {
-        hasValue = false;
-
-        onValueChange?.(hasValue);
-      }
+      onValueChange?.(input.value !== '');
     });
   }
 

--- a/enabler/src/providers/definitions.ts
+++ b/enabler/src/providers/definitions.ts
@@ -18,7 +18,6 @@ export interface GiftCardBuilder {
 
 export type GiftCardOptions = {
   onGiftCardReady?: () => Promise<void>;
-  onGiftCardSubmit?: () => Promise<void>;
   onValueChange?: (hasValue: boolean) => Promise<void>;
 };
 


### PR DESCRIPTION
Binding this in TypeScript (and JavaScript) ensures that your methods always operate with the correct context, preventing unexpected errors when methods are used as callbacks or passed around. This pull request binds the `balance` and `submit` methods to the class instance in the `FormComponent` constructor.

Also, I'm changing the <form> element in the `_getField` method to a <div> element in the `FormComponent` class to prevent the form being submitted when the user presses Enter.

I'm also fixing the handleChangeEvent to ensure that it also returns false when the input value is empty.

Finally I'm removing the unnecessary onGiftCardSubmit method